### PR TITLE
DRAFT: Minimum changes for an MSVC build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,14 +6,19 @@ message(STATUS "Local .env.cmake: ${LOCAL_ENV}")
 cmake_minimum_required(VERSION 3.7)
 set(NAME BananEngine)
 
-set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_C_COMPILER clang)
-set(CMAKE_CXX_COMPILER clang++)
-set(CMAKE_VERBOSE_MAKEFILE ON)
-set(CMAKE_CXX_FLAGS "-Wall -Wextra -O3 -gdwarf-4")
+# This needs to be after the "project" call
+#set(CMAKE_CXX_STANDARD 20)
+# This will only work if clang is in your path and breaks usage of other compilers
+# to force, set these as environment variables
+#set(CMAKE_C_COMPILER clang)
+#set(CMAKE_CXX_COMPILER clang++)
+#set(CMAKE_VERBOSE_MAKEFILE ON)
+# This is illegal, per our CMake expert... use "add_compile_options" after the "project" call
+#set(CMAKE_CXX_FLAGS "-Wall -Wextra -O3 -gdwarf-4")
 
 message(STATUS "using ${CMAKE_GENERATOR}")
 if (CMAKE_GENERATOR STREQUAL "MinGW Makefiles")
+    # This would be better in a "toolchain" file c.f. cmake documentation
     if (NOT MINGW_PATH)
         message(FATAL_ERROR "MINGW_PATH not set in .env.cmake")
     endif()
@@ -23,6 +28,8 @@ if (CMAKE_GENERATOR STREQUAL "MinGW Makefiles")
 endif()
 
 project(${NAME} VERSION 0.1)
+# ... here
+set(CMAKE_CXX_STANDARD 20)
 
 # find vulkan
 if (DEFINED VULKAN_SDK_PATH)
@@ -84,6 +91,8 @@ if (DEFINED OPENEXR_PATH)
     set(OPENEXR_FOUND "True")
 else()
     find_package(OpenEXR REQUIRED)
+    # OpenEXR installs Imath when built
+    find_package(Imath CONFIG REQUIRED)
     message(STATUS "Found OpenEXR: ${OpenEXR_LIBRARIES}")
 endif()
 
@@ -93,13 +102,16 @@ else()
     message(STATUS "Using openexr lib at: ${OPENEXR_LIBRARIES}")
 endif()
 
-include_directories(/usr/include/stb)
+# This will break Windows builds. use find_package instead.
+#include_directories(/usr/include/stb)
 
-add_library(BananEngine SHARED banan_window.cpp banan_pipeline.cpp banan_device.cpp banan_logger.cpp banan_swap_chain.cpp banan_model.cpp banan_game_object.cpp banan_renderer.cpp banan_camera.cpp banan_buffer.cpp banan_descriptor.cpp banan_image.cpp banan_entity_manager.cpp banan_entity_manager.cpp)
+# Symbols need to be exported on Windows for a SHARED library to be linkable.
+add_library(BananEngine STATIC banan_window.cpp banan_pipeline.cpp banan_device.cpp banan_logger.cpp banan_swap_chain.cpp banan_model.cpp banan_game_object.cpp banan_renderer.cpp banan_camera.cpp banan_buffer.cpp banan_descriptor.cpp banan_image.cpp banan_entity_manager.cpp banan_entity_manager.cpp)
 add_executable(BananEngineTest Tests/BananEngineTest.cpp Tests/main.cpp Tests/Systems/SimpleRenderSystem.cpp Tests/Systems/PointLightSystem.cpp Tests/KeyboardMovementController.cpp Tests/Systems/ComputeSystem.cpp Tests/Systems/ProcrastinatedRenderSystem.cpp Tests/Systems/ResolveSystem.cpp)
 target_link_libraries(BananEngineTest PRIVATE BananEngine)
 
 set_property(TARGET ${PROJECT_NAME} PROPERTY VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/build")
+set_property(TARGET BananEngineTest PROPERTY VS_DEBUGGER_ENVIRONMENT "PATH=$ENV{VULKAN_SDK}/bin;$ENV{CMAKE_PREFIX_PATH}/bin;C:/Program Files (x86)/Assimp/bin")
 
 if (WIN32)
     message(STATUS "CREATING BUILD FOR WINDOWS")
@@ -114,7 +126,9 @@ if (WIN32)
 
     target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR} ${Vulkan_INCLUDE_DIRS} ${ASSIMP_INCLUDE_DIRS} ${GLFW_INCLUDE_DIRS} ${GLM_PATH} ${ZLIB_INCLUDE_DIRS} ${OPENEXR_INCLUDE_DIRS})
     target_link_directories(${PROJECT_NAME} PUBLIC ${Vulkan_LIBRARIES} ${GLFW_LIB} ${OPENEXR_LIBRARIES})
-    target_link_libraries(${PROJECT_NAME} vulkan-1 ${ASSIMP_LIBRARIES} ${SDL2_LIBRARIES} OpenEXR Imath)
+    # Use the imported target instead of the explicit _DIRS and don't specify vulkan-1
+    # target_link_libraries(${PROJECT_NAME} ${ASSIMP_LIBRARIES} ${SDL2_LIBRARIES} OpenEXR::OpenEXR Vulkan::Vulkan Imath::Imath)
+    target_link_libraries(${PROJECT_NAME} assimp::assimp ${SDL2_LIBRARIES} OpenEXR::OpenEXR Vulkan::Vulkan Imath::Imath)
 
 elseif (UNIX)
     message(STATUS "CREATING BUILD FOR UNIX")
@@ -123,29 +137,40 @@ elseif (UNIX)
     target_link_libraries(${PROJECT_NAME} Imath OpenEXR ${Vulkan_LIBRARIES} ${ASSIMP_LIBRARIES} ${SDL2_LIBRARIES})
 endif()
 
-execute_process(COMMAND mkdir ${CMAKE_BINARY_DIR}/shaders)
-execute_process(COMMAND glslc ${CMAKE_SOURCE_DIR}/Tests/Shaders/triangle.frag -o ${CMAKE_BINARY_DIR}/shaders/triangle.frag.spv)
-execute_process(COMMAND glslc ${CMAKE_SOURCE_DIR}/Tests/Shaders/triangle.vert -o ${CMAKE_BINARY_DIR}/shaders/triangle.vert.spv)
+# The cross-platform way to make a directory
+execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory  ${CMAKE_BINARY_DIR}/shaders)
+# execute_process(COMMAND mkdir ${CMAKE_BINARY_DIR}/shaders)
 
-execute_process(COMMAND glslc ${CMAKE_SOURCE_DIR}/Tests/Shaders/point_light.frag -o ${CMAKE_BINARY_DIR}/shaders/point_light.frag.spv)
-execute_process(COMMAND glslc ${CMAKE_SOURCE_DIR}/Tests/Shaders/point_light.vert -o ${CMAKE_BINARY_DIR}/shaders/point_light.vert.spv)
+# Remove the requirement that glslc is in the path when the SDK is present
+if(TARGET Vulkan::glslc)
+    set(GLSLC_EXEC Vulkan::glslc)
+else()
+    set(GLSLC_EXEC glslc)
+endif()
+    
+execute_process(COMMAND ${GLSLC_EXEC} ${CMAKE_SOURCE_DIR}/Tests/Shaders/triangle.frag -o ${CMAKE_BINARY_DIR}/shaders/triangle.frag.spv)
+execute_process(COMMAND ${GLSLC_EXEC} ${CMAKE_SOURCE_DIR}/Tests/Shaders/triangle.vert -o ${CMAKE_BINARY_DIR}/shaders/triangle.vert.spv)
 
-execute_process(COMMAND glslc ${CMAKE_SOURCE_DIR}/Tests/Shaders/mrt.frag -o ${CMAKE_BINARY_DIR}/shaders/mrt.frag.spv)
-execute_process(COMMAND glslc ${CMAKE_SOURCE_DIR}/Tests/Shaders/mrt.vert -o ${CMAKE_BINARY_DIR}/shaders/mrt.vert.spv)
+execute_process(COMMAND ${GLSLC_EXEC} ${CMAKE_SOURCE_DIR}/Tests/Shaders/point_light.frag -o ${CMAKE_BINARY_DIR}/shaders/point_light.frag.spv)
+execute_process(COMMAND ${GLSLC_EXEC} ${CMAKE_SOURCE_DIR}/Tests/Shaders/point_light.vert -o ${CMAKE_BINARY_DIR}/shaders/point_light.vert.spv)
 
-execute_process(COMMAND glslc ${CMAKE_SOURCE_DIR}/Tests/Shaders/gbuffer.frag -o ${CMAKE_BINARY_DIR}/shaders/gbuffer.frag.spv)
-execute_process(COMMAND glslc ${CMAKE_SOURCE_DIR}/Tests/Shaders/gbuffer.vert -o ${CMAKE_BINARY_DIR}/shaders/gbuffer.vert.spv)
+execute_process(COMMAND ${GLSLC_EXEC} ${CMAKE_SOURCE_DIR}/Tests/Shaders/mrt.frag -o ${CMAKE_BINARY_DIR}/shaders/mrt.frag.spv)
+execute_process(COMMAND ${GLSLC_EXEC} ${CMAKE_SOURCE_DIR}/Tests/Shaders/mrt.vert -o ${CMAKE_BINARY_DIR}/shaders/mrt.vert.spv)
 
-execute_process(COMMAND glslc ${CMAKE_SOURCE_DIR}/Tests/Shaders/edge.frag -o ${CMAKE_BINARY_DIR}/shaders/edge.frag.spv)
-execute_process(COMMAND glslc ${CMAKE_SOURCE_DIR}/Tests/Shaders/edge.vert -o ${CMAKE_BINARY_DIR}/shaders/edge.vert.spv)
+execute_process(COMMAND ${GLSLC_EXEC} ${CMAKE_SOURCE_DIR}/Tests/Shaders/gbuffer.frag -o ${CMAKE_BINARY_DIR}/shaders/gbuffer.frag.spv)
+execute_process(COMMAND ${GLSLC_EXEC} ${CMAKE_SOURCE_DIR}/Tests/Shaders/gbuffer.vert -o ${CMAKE_BINARY_DIR}/shaders/gbuffer.vert.spv)
 
-execute_process(COMMAND glslc ${CMAKE_SOURCE_DIR}/Tests/Shaders/blend.frag -o ${CMAKE_BINARY_DIR}/shaders/blend.frag.spv)
-execute_process(COMMAND glslc ${CMAKE_SOURCE_DIR}/Tests/Shaders/blend.vert -o ${CMAKE_BINARY_DIR}/shaders/blend.vert.spv)
+execute_process(COMMAND ${GLSLC_EXEC} ${CMAKE_SOURCE_DIR}/Tests/Shaders/edge.frag -o ${CMAKE_BINARY_DIR}/shaders/edge.frag.spv)
+execute_process(COMMAND ${GLSLC_EXEC} ${CMAKE_SOURCE_DIR}/Tests/Shaders/edge.vert -o ${CMAKE_BINARY_DIR}/shaders/edge.vert.spv)
 
-execute_process(COMMAND glslc ${CMAKE_SOURCE_DIR}/Tests/Shaders/resolve.frag -o ${CMAKE_BINARY_DIR}/shaders/resolve.frag.spv)
-execute_process(COMMAND glslc ${CMAKE_SOURCE_DIR}/Tests/Shaders/resolve.vert -o ${CMAKE_BINARY_DIR}/shaders/resolve.vert.spv)
+execute_process(COMMAND ${GLSLC_EXEC} ${CMAKE_SOURCE_DIR}/Tests/Shaders/blend.frag -o ${CMAKE_BINARY_DIR}/shaders/blend.frag.spv)
+execute_process(COMMAND ${GLSLC_EXEC} ${CMAKE_SOURCE_DIR}/Tests/Shaders/blend.vert -o ${CMAKE_BINARY_DIR}/shaders/blend.vert.spv)
 
-execute_process(COMMAND glslc ${CMAKE_SOURCE_DIR}/Tests/Shaders/calc_normal_mats.comp -o ${CMAKE_BINARY_DIR}/shaders/calc_normal_mats.comp.spv)
+execute_process(COMMAND ${GLSLC_EXEC} ${CMAKE_SOURCE_DIR}/Tests/Shaders/resolve.frag -o ${CMAKE_BINARY_DIR}/shaders/resolve.frag.spv)
+execute_process(COMMAND ${GLSLC_EXEC} ${CMAKE_SOURCE_DIR}/Tests/Shaders/resolve.vert -o ${CMAKE_BINARY_DIR}/shaders/resolve.vert.spv)
 
-execute_process(COMMAND cp -r ${CMAKE_SOURCE_DIR}/Tests/banan_assets ${CMAKE_BINARY_DIR})
+execute_process(COMMAND ${GLSLC_EXEC} ${CMAKE_SOURCE_DIR}/Tests/Shaders/calc_normal_mats.comp -o ${CMAKE_BINARY_DIR}/shaders/calc_normal_mats.comp.spv)
+
+# Portable way to copy a directory
+execute_process(COMMAND ${CMAKE_COMMAND} -E  copy_directory ${CMAKE_SOURCE_DIR}/Tests/banan_assets ${CMAKE_BINARY_DIR}/banan_assets)
 

--- a/Tests/Systems/ResolveSystem.cpp
+++ b/Tests/Systems/ResolveSystem.cpp
@@ -1,7 +1,7 @@
 //
 // Created by yashr on 2/3/23.
 //
-
+#include <stdexcept>
 #include "ResolveSystem.h"
 
 namespace Banan {


### PR DESCRIPTION
Corrected some of the platform specific issues with CMake scripts, though by no means a final/correct version.  Needed to set a sensible CMAKE_PREFIX_PATH to pickup the findable components.

The force STATIC is because the .dll has no exported symbols and thus wasn't producing a .lib.

Other changes are annotated.